### PR TITLE
Fix AppBar Style

### DIFF
--- a/presentation/src/main/kotlin/com/hyunjung/aiku/presentation/ui/AikuPreviewTheme.kt
+++ b/presentation/src/main/kotlin/com/hyunjung/aiku/presentation/ui/AikuPreviewTheme.kt
@@ -1,0 +1,18 @@
+package com.hyunjung.aiku.presentation.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import com.hyunjung.aiku.core.designsystem.theme.AiKUTheme
+import com.hyunjung.aiku.core.navigation.AikuComposeNavigator
+import com.hyunjung.aiku.core.navigation.LocalComposeNavigator
+
+@Composable
+fun AikuPreviewTheme(
+    content: @Composable () -> Unit
+) {
+    CompositionLocalProvider(
+        LocalComposeNavigator provides AikuComposeNavigator()
+    ) {
+        AiKUTheme(content)
+    }
+}

--- a/presentation/src/main/kotlin/com/hyunjung/aiku/presentation/ui/NavigationBar.kt
+++ b/presentation/src/main/kotlin/com/hyunjung/aiku/presentation/ui/NavigationBar.kt
@@ -35,12 +35,9 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.hyunjung.aiku.core.designsystem.component.AikuSurface
 import com.hyunjung.aiku.core.designsystem.icon.AikuIcons
-import com.hyunjung.aiku.core.designsystem.theme.AiKUTheme
 import com.hyunjung.aiku.core.designsystem.theme.AikuColors
 import com.hyunjung.aiku.core.designsystem.theme.AikuTypography
-import com.hyunjung.aiku.core.navigation.AikuComposeNavigator
 import com.hyunjung.aiku.core.navigation.AikuScreen
-import com.hyunjung.aiku.core.navigation.LocalComposeNavigator
 import com.hyunjung.aiku.core.navigation.currentComposeNavigator
 
 
@@ -150,12 +147,8 @@ private fun RowScope.AikuNavigationBarItem(
 @Preview
 @Composable
 private fun AikuNavigationBarPreview() {
-    CompositionLocalProvider(
-        LocalComposeNavigator provides AikuComposeNavigator()
-    ) {
-        AiKUTheme {
-            AikuNavigationBar(AikuScreen.Home)
-        }
+    AikuPreviewTheme {
+        AikuNavigationBar(AikuScreen.Home)
     }
 }
 

--- a/presentation/src/main/kotlin/com/hyunjung/aiku/presentation/ui/TopAppBar.kt
+++ b/presentation/src/main/kotlin/com/hyunjung/aiku/presentation/ui/TopAppBar.kt
@@ -25,12 +25,9 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import com.hyunjung.aiku.core.designsystem.component.AikuIconButton
 import com.hyunjung.aiku.core.designsystem.icon.AikuIcons
-import com.hyunjung.aiku.core.designsystem.theme.AiKUTheme
 import com.hyunjung.aiku.core.designsystem.theme.AikuColors
 import com.hyunjung.aiku.core.designsystem.theme.AikuTypography
-import com.hyunjung.aiku.core.navigation.AikuComposeNavigator
 import com.hyunjung.aiku.core.navigation.AikuScreen
-import com.hyunjung.aiku.core.navigation.LocalComposeNavigator
 import com.hyunjung.aiku.core.navigation.currentComposeNavigator
 
 private val TopAppBarPadding = 20.dp
@@ -178,31 +175,25 @@ private fun TopAppBarBase(
 @Preview(showBackground = true)
 @Composable
 private fun AikuAppBarPreview() {
-    CompositionLocalProvider(
-        LocalComposeNavigator provides AikuComposeNavigator()
-    ) {
-        AiKUTheme { AikuLogoAppBar() }
+    AikuPreviewTheme {
+        AikuLogoAppBar()
     }
 }
 
 @Preview(showBackground = true)
 @Composable
 private fun NavigationAppBarPreview() {
-    CompositionLocalProvider(
-        LocalComposeNavigator provides AikuComposeNavigator()
-    ) {
-        AiKUTheme {
-            AikuBackAppBar(
-                title = stringResource(android.R.string.untitled),
-                actions = {
-                    AikuIconButton(
-                        onClick = {},
-                        imageVector = AikuIcons.MoreHoriz,
-                        contentDescription = null,
-                        size = 24.dp
-                    )
-                }
-            )
-        }
+    AikuPreviewTheme {
+        AikuBackAppBar(
+            title = stringResource(android.R.string.untitled),
+            actions = {
+                AikuIconButton(
+                    onClick = {},
+                    imageVector = AikuIcons.MoreHoriz,
+                    contentDescription = null,
+                    size = 24.dp
+                )
+            }
+        )
     }
 }


### PR DESCRIPTION
# PULL REQUEST

Figma UI 명세를 반영하여 AppBar 스타일을 개선하고, 프리뷰에서 일관된 테마와 내비게이션 환경을 제공하는 `AikuPreviewTheme` 컴포저블을 추가했습니다.

## Description

### Top
- 기존에 고정되어 있던 `TopAppBarHeight`(48dp)를 대체하여, `paddingValues` 파라미터로 여백을 더 유연하게 조정할 수 있도록 개선했습니다. 기본값은 20dp입니다.

### Bottom
- Figma UI 명세에 맞춰 AppBar 상단에 Border(구분선)를 추가했습니다.

### 공통
- AppBar의 배경색을 `AikuColors.White`에서 `AikuColors.Gray01`로 변경했습니다.
- 프리뷰에서 내비게이션을 제공할 수 있도록 `AikuPreviewTheme` 컴포저블을 추가했습니다.

```kotlin
@Composable
fun AikuPreviewTheme(
    content: @Composable () -> Unit
) {
    CompositionLocalProvider(
        LocalComposeNavigator provides AikuComposeNavigator()
    ) {
        AiKUTheme(content)
    }
}
