### PR TITLE
Feature/refactor profile image domain split

### DIFF
--- a/core/data/src/main/kotlin/com/hyunjung/aiku/core/data/repository/DefaultAuthRepository.kt
+++ b/core/data/src/main/kotlin/com/hyunjung/aiku/core/data/repository/DefaultAuthRepository.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import com.hyunjung.aiku.core.auth.social.SocialAuthManager
 import com.hyunjung.aiku.core.auth.social.di.SocialAuth
 import com.hyunjung.aiku.core.datastore.AuthSessionStore
-import com.hyunjung.aiku.core.datastore.UserDataStore
 import com.hyunjung.aiku.core.domain.repository.AuthRepository
 import com.hyunjung.aiku.core.model.auth.SignUpForm
 import com.hyunjung.aiku.core.model.auth.SocialSignInResult
@@ -21,7 +20,6 @@ class DefaultAuthRepository @Inject constructor(
     @SocialAuth(SocialType.KAKAO) private val kakao: SocialAuthManager,
     private val authRemoteDataSource: AuthRemoteDataSource,
     private val authSessionStore: AuthSessionStore,
-    private val userDataStore: UserDataStore,
 ) : AuthRepository {
 
     override val isSignedIn: Flow<Boolean> =
@@ -61,9 +59,6 @@ class DefaultAuthRepository @Inject constructor(
 
     override suspend fun signUp(signUpForm: SignUpForm): Flow<Unit> = flow {
         authRemoteDataSource.signUp(signUpForm)
-        userDataStore.setEmail(signUpForm.email)
-        userDataStore.setNickname(signUpForm.nickname)
-        userDataStore.setProfileImage(signUpForm.userProfileImage)
         emit(Unit)
     }
 

--- a/core/data/src/main/kotlin/com/hyunjung/aiku/core/data/repository/OfflineFirstUserDataRepository.kt
+++ b/core/data/src/main/kotlin/com/hyunjung/aiku/core/data/repository/OfflineFirstUserDataRepository.kt
@@ -13,15 +13,8 @@ class OfflineFirstUserDataRepository @Inject constructor(
 
     override val userData: Flow<UserData> = userDataStore.userData
 
-    override suspend fun setEmail(email: String) {
-        userDataStore.setEmail(email)
-    }
-
-    override suspend fun setNickname(nickname: String) {
+    override suspend fun setUserProfile(nickname: String, profileImage: UserProfileImage) {
         userDataStore.setNickname(nickname)
-    }
-
-    override suspend fun setProfileImage(profileImage: UserProfileImage) {
         userDataStore.setProfileImage(profileImage)
     }
 }

--- a/core/data/src/main/kotlin/com/hyunjung/aiku/core/data/repository/OfflineFirstUserDataRepository.kt
+++ b/core/data/src/main/kotlin/com/hyunjung/aiku/core/data/repository/OfflineFirstUserDataRepository.kt
@@ -3,18 +3,12 @@ package com.hyunjung.aiku.core.data.repository
 import com.hyunjung.aiku.core.datastore.UserDataStore
 import com.hyunjung.aiku.core.domain.repository.UserDataRepository
 import com.hyunjung.aiku.core.model.UserData
-import com.hyunjung.aiku.core.model.profile.UserProfileImage
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class OfflineFirstUserDataRepository @Inject constructor(
-    private val userDataStore: UserDataStore,
+    userDataStore: UserDataStore,
 ) : UserDataRepository {
 
     override val userData: Flow<UserData> = userDataStore.userData
-
-    override suspend fun setUserProfile(nickname: String, profileImage: UserProfileImage) {
-        userDataStore.setNickname(nickname)
-        userDataStore.setProfileImage(profileImage)
-    }
 }

--- a/core/data/src/test/kotlin/com/hyunjung/aiku/core/data/fake/FakeGroupDataSource.kt
+++ b/core/data/src/test/kotlin/com/hyunjung/aiku/core/data/fake/FakeGroupDataSource.kt
@@ -5,7 +5,7 @@ import com.hyunjung.aiku.core.model.group.GroupMember
 import com.hyunjung.aiku.core.model.group.JoinedGroup
 import com.hyunjung.aiku.core.model.profile.ProfileBackgroundColor
 import com.hyunjung.aiku.core.model.profile.AvatarType
-import com.hyunjung.aiku.core.model.profile.MemberProfileImage
+import com.hyunjung.aiku.core.model.profile.ProfileImage
 import com.hyunjung.aiku.core.network.datasource.GroupRemoteDataSource
 import java.time.LocalDateTime
 
@@ -33,12 +33,12 @@ class FakeGroupDataSource : GroupRemoteDataSource {
             GroupMember(
                 id = 1L,
                 nickname = "지정희",
-                memberProfileImage = MemberProfileImage.Photo(url = "http://amazon.s3.image.jpg")
+                profileImage = ProfileImage.Photo(url = "http://amazon.s3.image.jpg")
             ),
             GroupMember(
                 id = 2L,
                 nickname = "박소영",
-                memberProfileImage = MemberProfileImage.Avatar(
+                profileImage = ProfileImage.Avatar(
                     type = AvatarType.BOY,
                     backgroundColor = ProfileBackgroundColor.GREEN
                 )

--- a/core/data/src/test/kotlin/com/hyunjung/aiku/core/data/repository/DefaultGroupRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/hyunjung/aiku/core/data/repository/DefaultGroupRepositoryTest.kt
@@ -3,7 +3,7 @@ package com.hyunjung.aiku.core.data.repository
 import com.hyunjung.aiku.core.data.fake.FakeGroupDataSource
 import com.hyunjung.aiku.core.model.group.GroupDetail
 import com.hyunjung.aiku.core.model.profile.AvatarType
-import com.hyunjung.aiku.core.model.profile.MemberProfileImage
+import com.hyunjung.aiku.core.model.profile.ProfileImage
 import com.hyunjung.aiku.core.network.datasource.GroupRemoteDataSource
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -33,8 +33,8 @@ class DefaultGroupRepositoryTest {
         assertEquals("산학협력프로젝트", result.name)
         assertEquals(2, result.members.size)
         assertEquals("지정희", result.members[0].nickname)
-        val resultMemberProfile = result.members[0].memberProfileImage
-        if (resultMemberProfile is MemberProfileImage.Avatar) {
+        val resultMemberProfile = result.members[0].profileImage
+        if (resultMemberProfile is ProfileImage.Avatar) {
             assertEquals(AvatarType.BOY, resultMemberProfile.type)
         }
     }

--- a/core/datastore-proto/src/main/proto/com/hyunjung/aiku/data/user/user_data.proto
+++ b/core/datastore-proto/src/main/proto/com/hyunjung/aiku/data/user/user_data.proto
@@ -14,6 +14,6 @@ message UserDataProto {
 
   oneof profile_image {
     AvatarProto avatar = 6;
-    string file_path = 7;
+    string url = 7;
   }
 }

--- a/core/datastore/src/main/kotlin/com/hyunjung/aiku/core/datastore/UserDataStore.kt
+++ b/core/datastore/src/main/kotlin/com/hyunjung/aiku/core/datastore/UserDataStore.kt
@@ -10,21 +10,21 @@ import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 class UserDataStore @Inject constructor(
-    private val userdataProto: DataStore<UserDataProto>
+    private val userDataProto: DataStore<UserDataProto>
 ) {
 
-    val userData: Flow<UserData> = userdataProto.data.map { it.toModel() }
+    val userData: Flow<UserData> = userDataProto.data.map { it.toModel() }
 
     suspend fun setEmail(email: String) {
-        userdataProto.updateData { it.copy { this.email = email } }
+        userDataProto.updateData { it.copy { this.email = email } }
     }
 
     suspend fun setNickname(nickname: String) {
-        userdataProto.updateData { it.copy { this.nickname = nickname } }
+        userDataProto.updateData { it.copy { this.nickname = nickname } }
     }
 
     suspend fun setProfileImage(profileImage: UserProfileImage) {
-        userdataProto.updateData {
+        userDataProto.updateData {
             it.copy {
                 when (profileImage) {
                     is UserProfileImage.Avatar -> {

--- a/core/datastore/src/main/kotlin/com/hyunjung/aiku/core/datastore/UserDataStore.kt
+++ b/core/datastore/src/main/kotlin/com/hyunjung/aiku/core/datastore/UserDataStore.kt
@@ -4,7 +4,7 @@ import androidx.datastore.core.DataStore
 import com.hyunjung.aiku.core.datastore.mapper.toModel
 import com.hyunjung.aiku.core.datastore.mapper.toProto
 import com.hyunjung.aiku.core.model.UserData
-import com.hyunjung.aiku.core.model.profile.UserProfileImage
+import com.hyunjung.aiku.core.model.profile.ProfileImage
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
@@ -23,19 +23,19 @@ class UserDataStore @Inject constructor(
         userDataProto.updateData { it.copy { this.nickname = nickname } }
     }
 
-    suspend fun setProfileImage(profileImage: UserProfileImage) {
+    suspend fun setProfileImage(profileImage: ProfileImage) {
         userDataProto.updateData {
             it.copy {
                 when (profileImage) {
-                    is UserProfileImage.Avatar -> {
+                    is ProfileImage.Avatar -> {
                         avatar = AvatarProto.newBuilder()
                             .setType(profileImage.type.toProto())
                             .setBackgroundColor(profileImage.backgroundColor.toProto())
                             .build()
                     }
 
-                    is UserProfileImage.Photo -> {
-                        filePath = profileImage.file.absolutePath
+                    is ProfileImage.Photo -> {
+                        url = profileImage.url
                     }
                 }
             }

--- a/core/datastore/src/main/kotlin/com/hyunjung/aiku/core/datastore/mapper/UserDataMapper.kt
+++ b/core/datastore/src/main/kotlin/com/hyunjung/aiku/core/datastore/mapper/UserDataMapper.kt
@@ -3,9 +3,8 @@ package com.hyunjung.aiku.core.datastore.mapper
 import com.hyunjung.aiku.core.datastore.UserDataProto
 import com.hyunjung.aiku.core.model.UserData
 import com.hyunjung.aiku.core.model.profile.AvatarType
+import com.hyunjung.aiku.core.model.profile.ProfileImage
 import com.hyunjung.aiku.core.model.profile.ProfileBackgroundColor
-import com.hyunjung.aiku.core.model.profile.UserProfileImage
-import java.io.File
 
 internal fun UserDataProto.toModel(): UserData = UserData(
     id = id,
@@ -14,15 +13,15 @@ internal fun UserDataProto.toModel(): UserData = UserData(
     email = email,
     nickname = nickname,
     profileImage = when (profileImageCase) {
-        UserDataProto.ProfileImageCase.AVATAR -> UserProfileImage.Avatar(
+        UserDataProto.ProfileImageCase.AVATAR -> ProfileImage.Avatar(
             type = avatar.type.toModel(),
             backgroundColor = avatar.backgroundColor.toModel(),
         )
 
-        UserDataProto.ProfileImageCase.FILE_PATH ->
-            UserProfileImage.Photo(File(filePath))
+        UserDataProto.ProfileImageCase.URL ->
+            ProfileImage.Photo(url = url)
 
-        UserDataProto.ProfileImageCase.PROFILEIMAGE_NOT_SET -> UserProfileImage.Avatar(
+        UserDataProto.ProfileImageCase.PROFILEIMAGE_NOT_SET -> ProfileImage.Avatar(
             type = AvatarType.BOY,
             backgroundColor = ProfileBackgroundColor.GREEN
         )

--- a/core/domain/src/main/kotlin/com/hyunjung/aiku/core/domain/repository/UserDataRepository.kt
+++ b/core/domain/src/main/kotlin/com/hyunjung/aiku/core/domain/repository/UserDataRepository.kt
@@ -8,9 +8,5 @@ interface UserDataRepository {
 
     val userData: Flow<UserData>
 
-    suspend fun setEmail(email: String)
-
-    suspend fun setNickname(nickname: String)
-
-    suspend fun setProfileImage(profileImage: UserProfileImage)
+    suspend fun setUserProfile(nickname: String, profileImage: UserProfileImage)
 }

--- a/core/domain/src/main/kotlin/com/hyunjung/aiku/core/domain/repository/UserDataRepository.kt
+++ b/core/domain/src/main/kotlin/com/hyunjung/aiku/core/domain/repository/UserDataRepository.kt
@@ -1,12 +1,9 @@
 package com.hyunjung.aiku.core.domain.repository
 
 import com.hyunjung.aiku.core.model.UserData
-import com.hyunjung.aiku.core.model.profile.UserProfileImage
 import kotlinx.coroutines.flow.Flow
 
 interface UserDataRepository {
 
     val userData: Flow<UserData>
-
-    suspend fun setUserProfile(nickname: String, profileImage: UserProfileImage)
 }

--- a/core/model/src/main/kotlin/com/hyunjung/aiku/core/model/UserData.kt
+++ b/core/model/src/main/kotlin/com/hyunjung/aiku/core/model/UserData.kt
@@ -1,12 +1,12 @@
 package com.hyunjung.aiku.core.model
 
-import com.hyunjung.aiku.core.model.profile.UserProfileImage
+import com.hyunjung.aiku.core.model.profile.ProfileImage
 
 data class UserData(
     val id: Long,
     val email: String,
     val nickname: String,
     val kakaoId: String,
-    val profileImage: UserProfileImage,
+    val profileImage: ProfileImage,
     val point: Int = 0,
 )

--- a/core/model/src/main/kotlin/com/hyunjung/aiku/core/model/auth/SignUpForm.kt
+++ b/core/model/src/main/kotlin/com/hyunjung/aiku/core/model/auth/SignUpForm.kt
@@ -1,15 +1,15 @@
 package com.hyunjung.aiku.core.model.auth
 
-import com.hyunjung.aiku.core.model.profile.ProfileBackgroundColor
 import com.hyunjung.aiku.core.model.profile.AvatarType
-import com.hyunjung.aiku.core.model.profile.UserProfileImage
+import com.hyunjung.aiku.core.model.profile.ProfileBackgroundColor
+import com.hyunjung.aiku.core.model.profile.PendingProfileImage
 
 data class SignUpForm(
     val idToken: String,
     val socialType: SocialType,
     val email: String,
     val nickname: String = "",
-    val userProfileImage: UserProfileImage = UserProfileImage.Avatar(
+    val pendingProfileImage: PendingProfileImage = PendingProfileImage.Avatar(
         type = AvatarType.BOY,
         backgroundColor = ProfileBackgroundColor.GREEN,
     ),

--- a/core/model/src/main/kotlin/com/hyunjung/aiku/core/model/group/GroupMember.kt
+++ b/core/model/src/main/kotlin/com/hyunjung/aiku/core/model/group/GroupMember.kt
@@ -1,9 +1,9 @@
 package com.hyunjung.aiku.core.model.group
 
-import com.hyunjung.aiku.core.model.profile.MemberProfileImage
+import com.hyunjung.aiku.core.model.profile.ProfileImage
 
 data class GroupMember(
     override val id: Long,
     override val nickname: String,
-    override val memberProfileImage: MemberProfileImage
-) : GroupMemberBase(id, nickname, memberProfileImage)
+    override val profileImage: ProfileImage
+) : GroupMemberBase(id, nickname, profileImage)

--- a/core/model/src/main/kotlin/com/hyunjung/aiku/core/model/group/GroupMemberBase.kt
+++ b/core/model/src/main/kotlin/com/hyunjung/aiku/core/model/group/GroupMemberBase.kt
@@ -1,9 +1,9 @@
 package com.hyunjung.aiku.core.model.group
 
-import com.hyunjung.aiku.core.model.profile.MemberProfileImage
+import com.hyunjung.aiku.core.model.profile.ProfileImage
 
 abstract class GroupMemberBase(
     open val id: Long,
     open val nickname: String,
-    open val memberProfileImage: MemberProfileImage
+    open val profileImage: ProfileImage
 )

--- a/core/model/src/main/kotlin/com/hyunjung/aiku/core/model/group/GroupMemberWithArrivalTimeDiff.kt
+++ b/core/model/src/main/kotlin/com/hyunjung/aiku/core/model/group/GroupMemberWithArrivalTimeDiff.kt
@@ -1,10 +1,10 @@
 package com.hyunjung.aiku.core.model.group
 
-import com.hyunjung.aiku.core.model.profile.MemberProfileImage
+import com.hyunjung.aiku.core.model.profile.ProfileImage
 
 data class GroupMemberWithArrivalTimeDiff(
     override val id: Long,
     override val nickname: String,
-    override val memberProfileImage: MemberProfileImage,
+    override val profileImage: ProfileImage,
     val arrivalTimeDiffMinutes: Int
-) : GroupMemberBase(id, nickname, memberProfileImage)
+) : GroupMemberBase(id, nickname, profileImage)

--- a/core/model/src/main/kotlin/com/hyunjung/aiku/core/model/group/GroupMemberWithPoint.kt
+++ b/core/model/src/main/kotlin/com/hyunjung/aiku/core/model/group/GroupMemberWithPoint.kt
@@ -1,10 +1,10 @@
 package com.hyunjung.aiku.core.model.group
 
-import com.hyunjung.aiku.core.model.profile.MemberProfileImage
+import com.hyunjung.aiku.core.model.profile.ProfileImage
 
 data class GroupMemberWithPoint(
     override val id: Long,
     override val nickname: String,
-    override val memberProfileImage: MemberProfileImage,
+    override val profileImage: ProfileImage,
     val point: Int
-) : GroupMemberBase(id, nickname, memberProfileImage)
+) : GroupMemberBase(id, nickname, profileImage)

--- a/core/model/src/main/kotlin/com/hyunjung/aiku/core/model/profile/PendingProfileImage.kt
+++ b/core/model/src/main/kotlin/com/hyunjung/aiku/core/model/profile/PendingProfileImage.kt
@@ -2,14 +2,14 @@ package com.hyunjung.aiku.core.model.profile
 
 import java.io.File
 
-sealed interface UserProfileImage {
+sealed interface PendingProfileImage {
 
     data class Photo(
         val file: File,
-    ) : UserProfileImage
+    ) : PendingProfileImage
 
     data class Avatar(
         val type: AvatarType,
         val backgroundColor: ProfileBackgroundColor
-    ) : UserProfileImage
+    ) : PendingProfileImage
 }

--- a/core/model/src/main/kotlin/com/hyunjung/aiku/core/model/profile/ProfileImage.kt
+++ b/core/model/src/main/kotlin/com/hyunjung/aiku/core/model/profile/ProfileImage.kt
@@ -1,13 +1,13 @@
 package com.hyunjung.aiku.core.model.profile
 
-sealed interface MemberProfileImage {
+sealed interface ProfileImage {
 
     data class Photo(
         val url: String
-    ) : MemberProfileImage
+    ) : ProfileImage
 
     data class Avatar(
         val type: AvatarType,
         val backgroundColor: ProfileBackgroundColor
-    ) : MemberProfileImage
+    ) : ProfileImage
 }

--- a/core/network/src/main/kotlin/com/hyunjung/aiku/core/network/datasource/KtorAuthRemoteDataSource.kt
+++ b/core/network/src/main/kotlin/com/hyunjung/aiku/core/network/datasource/KtorAuthRemoteDataSource.kt
@@ -24,7 +24,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.headers
 import javax.inject.Inject
 
-class DefaultAuthRemoteDataSource @Inject constructor(
+class KtorAuthRemoteDataSource @Inject constructor(
     @UnauthenticatedClient private val client: HttpClient,
 ) : AuthRemoteDataSource {
 

--- a/core/network/src/main/kotlin/com/hyunjung/aiku/core/network/datasource/KtorAuthRemoteDataSource.kt
+++ b/core/network/src/main/kotlin/com/hyunjung/aiku/core/network/datasource/KtorAuthRemoteDataSource.kt
@@ -39,7 +39,7 @@ class KtorAuthRemoteDataSource @Inject constructor(
         client.post(UserResource()) {
             setBody(MultiPartFormDataContent(formData {
                 appendBaseFields(signUpForm)
-                appendProfileFields(signUpForm.userProfileImage)
+                appendProfileFields(signUpForm.pendingProfileImage)
                 appendAgreementFields(signUpForm.agreedTerms)
                 append("recommenderNickname", signUpForm.recommenderNickname)
             }))

--- a/core/network/src/main/kotlin/com/hyunjung/aiku/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/kotlin/com/hyunjung/aiku/core/network/di/NetworkModule.kt
@@ -1,7 +1,7 @@
 package com.hyunjung.aiku.core.network.di
 
 import com.hyunjung.aiku.core.network.datasource.AuthRemoteDataSource
-import com.hyunjung.aiku.core.network.datasource.DefaultAuthRemoteDataSource
+import com.hyunjung.aiku.core.network.datasource.KtorAuthRemoteDataSource
 import com.hyunjung.aiku.core.network.datasource.GroupRemoteDataSource
 import com.hyunjung.aiku.core.network.datasource.KtorGroupRemoteDataSource
 import com.hyunjung.aiku.core.network.datasource.KtorScheduleRemoteDataSource
@@ -17,7 +17,7 @@ internal abstract class NetworkModule {
 
     @Binds
     abstract fun bindAuthRemoteDataSource(
-        authRemoteDataSource: DefaultAuthRemoteDataSource
+        authRemoteDataSource: KtorAuthRemoteDataSource
     ): AuthRemoteDataSource
 
     @Binds

--- a/core/network/src/main/kotlin/com/hyunjung/aiku/core/network/extension/FormDataExtension.kt
+++ b/core/network/src/main/kotlin/com/hyunjung/aiku/core/network/extension/FormDataExtension.kt
@@ -2,7 +2,7 @@ package com.hyunjung.aiku.core.network.extension
 
 import com.hyunjung.aiku.core.model.auth.SignUpForm
 import com.hyunjung.aiku.core.model.auth.TermsType
-import com.hyunjung.aiku.core.model.profile.UserProfileImage
+import com.hyunjung.aiku.core.model.profile.PendingProfileImage
 import io.ktor.client.request.forms.FormBuilder
 import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
@@ -14,9 +14,9 @@ internal fun FormBuilder.appendBaseFields(form: SignUpForm) {
     append("idToken", form.idToken)
 }
 
-internal fun FormBuilder.appendProfileFields(profile: UserProfileImage) {
+internal fun FormBuilder.appendProfileFields(profile: PendingProfileImage) {
     when (profile) {
-        is UserProfileImage.Photo -> {
+        is PendingProfileImage.Photo -> {
             append("memberProfile.profileType", "IMG")
             append(
                 "memberProfile.profileImg",
@@ -28,7 +28,7 @@ internal fun FormBuilder.appendProfileFields(profile: UserProfileImage) {
             )
         }
 
-        is UserProfileImage.Avatar -> {
+        is PendingProfileImage.Avatar -> {
             append("memberProfile.profileType", "CHAR")
             append("memberProfile.profileCharacter", profile.type.code)
             append("memberProfile.profileBackground", profile.backgroundColor.name)

--- a/core/network/src/main/kotlin/com/hyunjung/aiku/core/network/model/GroupMemberResponse.kt
+++ b/core/network/src/main/kotlin/com/hyunjung/aiku/core/network/model/GroupMemberResponse.kt
@@ -14,5 +14,5 @@ fun GroupMemberResponse.toModel(): GroupMember =
     GroupMember(
         id = memberId,
         nickname = nickname,
-        memberProfileImage = memberProfile.toModel()
+        profileImage = memberProfile.toModel()
     )

--- a/core/network/src/main/kotlin/com/hyunjung/aiku/core/network/model/MemberProfileResponse.kt
+++ b/core/network/src/main/kotlin/com/hyunjung/aiku/core/network/model/MemberProfileResponse.kt
@@ -2,7 +2,7 @@ package com.hyunjung.aiku.core.network.model
 
 import com.hyunjung.aiku.core.model.profile.ProfileBackgroundColor
 import com.hyunjung.aiku.core.model.profile.AvatarType
-import com.hyunjung.aiku.core.model.profile.MemberProfileImage
+import com.hyunjung.aiku.core.model.profile.ProfileImage
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -13,11 +13,11 @@ data class MemberProfileResponse(
     val profileBackground: String? = null
 )
 
-fun MemberProfileResponse.toModel(): MemberProfileImage =
+fun MemberProfileResponse.toModel(): ProfileImage =
     if (profileType == "IMG" && !profileImg.isNullOrBlank()) {
-        MemberProfileImage.Photo(url = profileImg)
+        ProfileImage.Photo(url = profileImg)
     } else {
-        MemberProfileImage.Avatar(
+        ProfileImage.Avatar(
             type = when (profileCharacter) {
                 "C01" -> AvatarType.BOY
                 "C02" -> AvatarType.BABY

--- a/core/network/src/test/kotlin/com/hyunjung/aiku/core/network/datasource/KtorGroupDataSourceImplTest.kt
+++ b/core/network/src/test/kotlin/com/hyunjung/aiku/core/network/datasource/KtorGroupDataSourceImplTest.kt
@@ -3,7 +3,7 @@ package com.hyunjung.aiku.core.network.datasource
 import com.hyunjung.aiku.core.model.group.GroupDetail
 import com.hyunjung.aiku.core.model.group.JoinedGroup
 import com.hyunjung.aiku.core.model.profile.AvatarType
-import com.hyunjung.aiku.core.model.profile.MemberProfileImage
+import com.hyunjung.aiku.core.model.profile.ProfileImage
 import com.hyunjung.aiku.core.network.datasource.mock.groupMockEngine
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
@@ -43,8 +43,8 @@ class KtorGroupDataSourceImplTest {
         assertEquals("산학협력프로젝트", result.name)
         assertEquals(2, result.members.size)
         assertEquals("지정희", result.members[0].nickname)
-        val resultMemberProfile = result.members[0].memberProfileImage
-        if (resultMemberProfile is MemberProfileImage.Avatar) {
+        val resultMemberProfile = result.members[0].profileImage
+        if (resultMemberProfile is ProfileImage.Avatar) {
             assertEquals(AvatarType.BOY, resultMemberProfile.type)
         }
     }

--- a/core/ui/src/main/kotlin/com/hyunjung/aiku/core/ui/component/common/ProfileImagePicker.kt
+++ b/core/ui/src/main/kotlin/com/hyunjung/aiku/core/ui/component/common/ProfileImagePicker.kt
@@ -26,31 +26,34 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import coil.compose.rememberAsyncImagePainter
 import com.hyunjung.aiku.core.designsystem.component.AikuClickableSurface
 import com.hyunjung.aiku.core.designsystem.component.AikuText
 import com.hyunjung.aiku.core.designsystem.icon.AikuIcons
 import com.hyunjung.aiku.core.designsystem.theme.AiKUTheme
 import com.hyunjung.aiku.core.model.profile.AvatarType
 import com.hyunjung.aiku.core.model.profile.ProfileBackgroundColor
-import com.hyunjung.aiku.core.model.profile.UserProfileImage
+import com.hyunjung.aiku.core.model.profile.PendingProfileImage
 import com.hyunjung.aiku.core.ui.R
 import com.hyunjung.aiku.core.ui.component.dialog.CharacterProfilePickerDialog
-import com.hyunjung.aiku.core.ui.extension.backgroundColor
-import com.hyunjung.aiku.core.ui.extension.padding
-import com.hyunjung.aiku.core.ui.extension.painter
+import com.hyunjung.aiku.core.ui.extension.toColor
+import com.hyunjung.aiku.core.ui.extension.toPainter
 import com.hyunjung.aiku.core.ui.preview.AikuPreviewTheme
 
 @Composable
 fun ProfileImagePicker(
-    userProfileImage: UserProfileImage,
+    pendingProfileImage: PendingProfileImage,
     isOptionMenuVisible: Boolean,
     onProfileImageOptionMenuDisMiss: () -> Unit,
     onEditClick: () -> Unit,
-    onCharacterProfileSelected: (UserProfileImage.Avatar) -> Unit,
+    onCharacterProfileSelected: (PendingProfileImage.Avatar) -> Unit,
     onAlbumImageSelected: (Uri) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -61,8 +64,8 @@ fun ProfileImagePicker(
     ) { uri: Uri? -> uri?.let { onAlbumImageSelected(uri) } }
 
     if (showCharacterPicker) {
-        val avatar = userProfileImage as? UserProfileImage.Avatar
-            ?: UserProfileImage.Avatar(
+        val avatar = pendingProfileImage as? PendingProfileImage.Avatar
+            ?: PendingProfileImage.Avatar(
                 type = AvatarType.BOY,
                 backgroundColor = ProfileBackgroundColor.GREEN
             )
@@ -77,15 +80,15 @@ fun ProfileImagePicker(
         Box(modifier = Modifier.align(Alignment.Center)) {
             AikuClickableSurface(
                 onClick = onEditClick,
-                color = userProfileImage.backgroundColor(),
+                color = pendingProfileImage.backgroundColor(),
                 shape = CircleShape,
             ) {
                 Image(
-                    painter = userProfileImage.painter(),
+                    painter = pendingProfileImage.painter(),
                     contentDescription = stringResource(R.string.profile_image_picker_description),
                     modifier = Modifier
                         .size(148.dp)
-                        .padding(userProfileImage.padding()),
+                        .padding(pendingProfileImage.padding()),
                     contentScale = ContentScale.Crop
                 )
             }
@@ -177,7 +180,7 @@ private fun ProfileImageOptionItem(
 private fun ProfileImagePickerCollapsedPreview() {
     AikuPreviewTheme {
         ProfileImagePicker(
-            userProfileImage = UserProfileImage.Avatar(
+            pendingProfileImage = PendingProfileImage.Avatar(
                 type = AvatarType.BOY,
                 backgroundColor = ProfileBackgroundColor.GREEN
             ),
@@ -196,7 +199,7 @@ private fun ProfileImagePickerCollapsedPreview() {
 private fun ProfileImagePickerExpandedPreview() {
     AikuPreviewTheme {
         ProfileImagePicker(
-            userProfileImage = UserProfileImage.Avatar(
+            pendingProfileImage = PendingProfileImage.Avatar(
                 type = AvatarType.BOY,
                 backgroundColor = ProfileBackgroundColor.GREEN
             ),
@@ -208,4 +211,21 @@ private fun ProfileImagePickerExpandedPreview() {
             modifier = Modifier.padding(24.dp)
         )
     }
+}
+
+@Composable
+private fun PendingProfileImage.painter(): Painter = when (this) {
+    is PendingProfileImage.Avatar -> type.toPainter()
+    is PendingProfileImage.Photo -> rememberAsyncImagePainter(model = file)
+}
+
+@Composable
+private fun PendingProfileImage.backgroundColor(): Color = when (this) {
+    is PendingProfileImage.Avatar -> backgroundColor.toColor()
+    else -> Color.Unspecified
+}
+
+private fun PendingProfileImage.padding(): Dp = when (this) {
+    is PendingProfileImage.Avatar -> 20.dp
+    else -> 0.dp
 }

--- a/core/ui/src/main/kotlin/com/hyunjung/aiku/core/ui/component/dialog/CharacterProfilePickerDialog.kt
+++ b/core/ui/src/main/kotlin/com/hyunjung/aiku/core/ui/component/dialog/CharacterProfilePickerDialog.kt
@@ -29,9 +29,9 @@ import com.hyunjung.aiku.core.designsystem.component.AikuDialog
 import com.hyunjung.aiku.core.designsystem.component.AikuSurface
 import com.hyunjung.aiku.core.designsystem.component.AikuText
 import com.hyunjung.aiku.core.designsystem.theme.AiKUTheme
-import com.hyunjung.aiku.core.model.profile.UserProfileImage
-import com.hyunjung.aiku.core.model.profile.ProfileBackgroundColor
 import com.hyunjung.aiku.core.model.profile.AvatarType
+import com.hyunjung.aiku.core.model.profile.ProfileBackgroundColor
+import com.hyunjung.aiku.core.model.profile.PendingProfileImage
 import com.hyunjung.aiku.core.ui.R
 import com.hyunjung.aiku.core.ui.extension.getDescription
 import com.hyunjung.aiku.core.ui.extension.toColor
@@ -40,9 +40,9 @@ import com.hyunjung.aiku.core.ui.preview.AikuPreviewTheme
 
 @Composable
 fun CharacterProfilePickerDialog(
-    avatar: UserProfileImage.Avatar,
+    avatar: PendingProfileImage.Avatar,
     onDismiss: () -> Unit,
-    onCharacterProfileSelected: (UserProfileImage.Avatar) -> Unit,
+    onCharacterProfileSelected: (PendingProfileImage.Avatar) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var selectedCharacter by remember { mutableStateOf(avatar.type) }
@@ -129,7 +129,7 @@ fun CharacterProfilePickerDialog(
             AikuButton(
                 onClick = {
                     onCharacterProfileSelected(
-                        UserProfileImage.Avatar(
+                        PendingProfileImage.Avatar(
                             type = selectedCharacter,
                             backgroundColor = selectedBackgroundColor,
                         )
@@ -155,7 +155,7 @@ fun CharacterProfilePickerDialog(
 private fun CreateGroupDialogPreview() {
     AikuPreviewTheme {
         CharacterProfilePickerDialog(
-            UserProfileImage.Avatar(
+            PendingProfileImage.Avatar(
                 type = AvatarType.BOY,
                 backgroundColor = ProfileBackgroundColor.GREEN,
             ),

--- a/core/ui/src/main/kotlin/com/hyunjung/aiku/core/ui/extension/MemberProfileExtension.kt
+++ b/core/ui/src/main/kotlin/com/hyunjung/aiku/core/ui/extension/MemberProfileExtension.kt
@@ -3,37 +3,17 @@ package com.hyunjung.aiku.core.ui.extension
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
-import com.hyunjung.aiku.core.model.profile.MemberProfileImage
-import com.hyunjung.aiku.core.model.profile.UserProfileImage
+import com.hyunjung.aiku.core.model.profile.ProfileImage
 
 @Composable
-fun UserProfileImage.painter(): Painter = when (this) {
-    is UserProfileImage.Avatar -> type.toPainter()
-    is UserProfileImage.Photo -> rememberAsyncImagePainter(model = file)
+fun ProfileImage.painter(): Painter = when (this) {
+    is ProfileImage.Photo -> rememberAsyncImagePainter(model = url)
+    is ProfileImage.Avatar -> type.toPainter()
 }
 
 @Composable
-fun UserProfileImage.backgroundColor(): Color = when (this) {
-    is UserProfileImage.Avatar -> backgroundColor.toColor()
-    else -> Color.Unspecified
-}
-
-fun UserProfileImage.padding(): Dp = when (this) {
-    is UserProfileImage.Avatar -> 20.dp
-    else -> 0.dp
-}
-
-@Composable
-fun MemberProfileImage.painter(): Painter = when (this) {
-    is MemberProfileImage.Photo -> rememberAsyncImagePainter(model = url)
-    is MemberProfileImage.Avatar -> type.toPainter()
-}
-
-@Composable
-fun MemberProfileImage.backgroundColor(): Color = when (this) {
-    is MemberProfileImage.Avatar -> backgroundColor.toColor()
+fun ProfileImage.backgroundColor(): Color = when (this) {
+    is ProfileImage.Avatar -> backgroundColor.toColor()
     else -> Color.Unspecified
 }

--- a/core/ui/src/main/kotlin/com/hyunjung/aiku/core/ui/preview/PreviewParameterData.kt
+++ b/core/ui/src/main/kotlin/com/hyunjung/aiku/core/ui/preview/PreviewParameterData.kt
@@ -4,7 +4,7 @@ import com.hyunjung.aiku.core.model.group.GroupMember
 import com.hyunjung.aiku.core.model.group.GroupSchedule
 import com.hyunjung.aiku.core.model.group.JoinedGroup
 import com.hyunjung.aiku.core.model.profile.AvatarType
-import com.hyunjung.aiku.core.model.profile.MemberProfileImage
+import com.hyunjung.aiku.core.model.profile.ProfileImage
 import com.hyunjung.aiku.core.model.profile.ProfileBackgroundColor
 import com.hyunjung.aiku.core.model.schedule.Location
 import com.hyunjung.aiku.core.model.schedule.ScheduleStatus
@@ -62,7 +62,7 @@ object PreviewParameterData {
         GroupMember(
             id = (index + 1).toLong(),
             nickname = "사용자${index + 1}",
-            memberProfileImage = MemberProfileImage.Avatar(
+            profileImage = ProfileImage.Avatar(
                 type = AvatarType.entries[index],
                 backgroundColor = ProfileBackgroundColor.entries[index]
             )

--- a/feature/auth/src/main/kotlin/com/hyunjung/aiku/feature/auth/signup/SignUpProfileScreen.kt
+++ b/feature/auth/src/main/kotlin/com/hyunjung/aiku/feature/auth/signup/SignUpProfileScreen.kt
@@ -32,9 +32,9 @@ import com.hyunjung.aiku.core.designsystem.component.textfield.AikuLimitedTextFi
 import com.hyunjung.aiku.core.designsystem.component.textfield.AikuTextField
 import com.hyunjung.aiku.core.designsystem.component.textfield.AikuTextFieldDefaults
 import com.hyunjung.aiku.core.designsystem.theme.AiKUTheme
-import com.hyunjung.aiku.core.model.profile.UserProfileImage
 import com.hyunjung.aiku.core.model.auth.SignUpForm
 import com.hyunjung.aiku.core.model.auth.SocialType
+import com.hyunjung.aiku.core.model.profile.PendingProfileImage
 import com.hyunjung.aiku.core.ui.component.common.LoadingOverlayContainer
 import com.hyunjung.aiku.core.ui.component.common.NicknameField
 import com.hyunjung.aiku.core.ui.component.common.ProfileImagePicker
@@ -48,7 +48,7 @@ internal fun SignUpProfileScreen(
     uiState: SignUpProfileUiState = SignUpProfileUiState.Idle,
     snackbarHostState: AikuSnackbarHostState = AikuSnackbarHostState(),
     onNicknameChange: (String) -> Unit = {},
-    onCharacterProfileSelected: (UserProfileImage.Avatar) -> Unit = {},
+    onCharacterProfileSelected: (PendingProfileImage.Avatar) -> Unit = {},
     onAlbumImageSelected: (Uri) -> Unit = {},
     checkNicknameDuplication: () -> Unit = {},
     onRecommenderNicknameChange: (String) -> Unit = {},
@@ -89,7 +89,7 @@ internal fun SignUpProfileScreen(
 
             Spacer(Modifier.height(32.dp))
             ProfileImagePicker(
-                userProfileImage = signUpFormState.userProfileImage,
+                pendingProfileImage = signUpFormState.pendingProfileImage,
                 isOptionMenuVisible = isOptionMenuVisible,
                 onProfileImageOptionMenuDisMiss = { isOptionMenuVisible = false },
                 onEditClick = { isOptionMenuVisible = true },

--- a/feature/auth/src/main/kotlin/com/hyunjung/aiku/feature/auth/signup/SignUpScreen.kt
+++ b/feature/auth/src/main/kotlin/com/hyunjung/aiku/feature/auth/signup/SignUpScreen.kt
@@ -11,8 +11,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hyunjung.aiku.core.designsystem.component.snackbar.AikuSnackbarHostState
-import com.hyunjung.aiku.core.model.profile.UserProfileImage
 import com.hyunjung.aiku.core.model.auth.TermsType
+import com.hyunjung.aiku.core.model.profile.PendingProfileImage
 import com.hyunjung.aiku.core.ui.extension.toCompressedFile
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -51,12 +51,12 @@ internal fun SignUpScreen(
                 signUpFormState = signUpFormState,
                 snackbarHostState = snackbarHostState,
                 onNicknameChange = viewModel::onNicknameChange,
-                onCharacterProfileSelected = viewModel::onProfileChange,
+                onCharacterProfileSelected = viewModel::onProfileImageChange,
                 onAlbumImageSelected = { uri ->
                     coroutineScope.launch {
                         try {
                             val file = uri.toCompressedFile(localContext)
-                            viewModel.onProfileChange(UserProfileImage.Photo(file))
+                            viewModel.onProfileImageChange(PendingProfileImage.Photo(file))
                         } catch (_: Exception) {
                             viewModel.onAlbumImageCompressionFailed()
                         }

--- a/feature/auth/src/main/kotlin/com/hyunjung/aiku/feature/auth/signup/SignUpViewModel.kt
+++ b/feature/auth/src/main/kotlin/com/hyunjung/aiku/feature/auth/signup/SignUpViewModel.kt
@@ -5,9 +5,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.hyunjung.aiku.core.domain.repository.AuthRepository
-import com.hyunjung.aiku.core.model.profile.UserProfileImage
 import com.hyunjung.aiku.core.model.auth.SignUpForm
 import com.hyunjung.aiku.core.model.auth.TermsType
+import com.hyunjung.aiku.core.model.profile.PendingProfileImage
 import com.hyunjung.aiku.core.navigation.AuthRoute
 import com.hyunjung.aiku.core.result.Result
 import com.hyunjung.aiku.core.result.asResult
@@ -59,8 +59,8 @@ class SignUpViewModel @Inject constructor(
         _signUpFormState.update { it.copy(isNicknameDuplicated = false) }
     }
 
-    fun onProfileChange(userProfileImage: UserProfileImage) {
-        _signUpFormState.update { it.copy(userProfileImage = userProfileImage) }
+    fun onProfileImageChange(pendingProfileImage: PendingProfileImage) {
+        _signUpFormState.update { it.copy(pendingProfileImage = pendingProfileImage) }
     }
 
     fun onAlbumImageCompressionFailed() {

--- a/feature/group-detail/src/main/kotlin/com/hyunjung/aiku/feature/group/detail/component/GroupMemberTab.kt
+++ b/feature/group-detail/src/main/kotlin/com/hyunjung/aiku/feature/group/detail/component/GroupMemberTab.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.unit.dp
 import com.hyunjung.aiku.core.designsystem.component.LocalAikuTextStyle
 import com.hyunjung.aiku.core.designsystem.theme.AiKUTheme
 import com.hyunjung.aiku.core.model.group.GroupMember
-import com.hyunjung.aiku.core.model.profile.MemberProfileImage
+import com.hyunjung.aiku.core.model.profile.ProfileImage
 import com.hyunjung.aiku.core.ui.component.common.EmptyPlaceholder
 import com.hyunjung.aiku.core.ui.extension.backgroundColor
 import com.hyunjung.aiku.core.ui.extension.painter
@@ -66,12 +66,12 @@ internal fun GroupMemberTab(
 
                 items(items = groupMembers, key = { it.id }) { member ->
                     GroupMemberProfile(
-                        image = member.memberProfileImage.painter(),
+                        image = member.profileImage.painter(),
                         label = member.nickname,
-                        backgroundColor = member.memberProfileImage.backgroundColor(),
+                        backgroundColor = member.profileImage.backgroundColor(),
                         contentDescription = stringResource(R.string.group_detail_member_profile_image_description),
                         onClick = { onMemberClick(member.id) },
-                        imagePadding = if (member.memberProfileImage is MemberProfileImage.Avatar) {
+                        imagePadding = if (member.profileImage is ProfileImage.Avatar) {
                             PaddingValues(8.dp)
                         } else {
                             PaddingValues(0.dp)

--- a/feature/profile/src/main/kotlin/com/hyunjung/aiku/feature/profile/MyPageScreen.kt
+++ b/feature/profile/src/main/kotlin/com/hyunjung/aiku/feature/profile/MyPageScreen.kt
@@ -45,8 +45,8 @@ import com.hyunjung.aiku.core.designsystem.icon.AikuIcons
 import com.hyunjung.aiku.core.designsystem.theme.AiKUTheme
 import com.hyunjung.aiku.core.model.UserData
 import com.hyunjung.aiku.core.model.profile.AvatarType
+import com.hyunjung.aiku.core.model.profile.ProfileImage
 import com.hyunjung.aiku.core.model.profile.ProfileBackgroundColor
-import com.hyunjung.aiku.core.model.profile.UserProfileImage
 import com.hyunjung.aiku.core.navigation.AikuRoute
 import com.hyunjung.aiku.core.ui.component.common.AikuNavigationBar
 import com.hyunjung.aiku.core.ui.extension.backgroundColor
@@ -244,7 +244,7 @@ private fun MyPageHeader(
 private fun UserProfileInfo(
     nickname: String,
     email: String,
-    profileImage: UserProfileImage,
+    profileImage: ProfileImage,
     modifier: Modifier = Modifier
 ) {
     Row {
@@ -254,7 +254,7 @@ private fun UserProfileInfo(
                 onClick = {},
                 color = profileImage.backgroundColor(),
                 shape = CircleShape,
-                contentPadding = if (profileImage is UserProfileImage.Avatar) PaddingValues(12.dp) else PaddingValues(
+                contentPadding = if (profileImage is ProfileImage.Avatar) PaddingValues(12.dp) else PaddingValues(
                     0.dp
                 )
             ) {
@@ -337,7 +337,7 @@ private fun MyPageScreenPreview() {
         email = "email@example.com",
         nickname = "아이쿠",
         kakaoId = "email@kakao.com",
-        profileImage = UserProfileImage.Avatar(
+        profileImage = ProfileImage.Avatar(
             type = AvatarType.BOY,
             backgroundColor = ProfileBackgroundColor.GREEN
         ),


### PR DESCRIPTION
# PULL REQUEST
- 프로필 이미지 도메인 정리(임시/영속 분리)와 URL 저장 전환, Auth 원격 DS 리네임, 경미한 네이밍 오타 수정

## Description
### 프로필 이미지 도메인/모델 정리
- `MemberProfileImage` → **`ProfileImage`** (도메인 전역에서 사용하는 사용자 프로필)
  - `ProfileImage.Avatar(type, backgroundColor)`
  - `ProfileImage.Photo(url)` ← 서버가 내려주는 **URL**만 보관
- `UserProfileImage` → **`PendingProfileImage`** (가입/업로드 전 임시 모델)
  - `PendingProfileImage.Avatar(...)`
  - `PendingProfileImage.Photo(file)` ← 갤러리/카메라로 고른 **로컬 파일**

### AuthRemoteDataSource 리네임
- `DefaultAuthRemoteDataSource` → **`KtorAuthRemoteDataSource`**
  - 구현 방식(Ktor) 명확화

### DataStore/Proto 영속 방식 전환
- `UserDataStore`에서 프로필 이미지 **파일 경로 대신 URL** 저장
- Proto `oneof profile_image { AvatarProto avatar; string file_path; }` 구조 유지(서로 배타)

### 기타
- **chore**: `UserDataStore` 필드명 오타 수정  
  - `userdataProto` → `userDataProto`
