### PR TITLE
Feature/userdata remote datasource

### DIFF
--- a/core/network/src/main/kotlin/com/hyunjung/aiku/core/network/datasource/KtorUserRemoteDataSource.kt
+++ b/core/network/src/main/kotlin/com/hyunjung/aiku/core/network/datasource/KtorUserRemoteDataSource.kt
@@ -1,0 +1,21 @@
+package com.hyunjung.aiku.core.network.datasource
+
+import com.hyunjung.aiku.core.model.UserData
+import com.hyunjung.aiku.core.network.di.AuthorizedClient
+import com.hyunjung.aiku.core.network.extension.get
+import com.hyunjung.aiku.core.network.model.ApiResponse
+import com.hyunjung.aiku.core.network.model.UserDataResponse
+import com.hyunjung.aiku.core.network.model.toModel
+import com.hyunjung.aiku.core.network.resource.UserResource
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import javax.inject.Inject
+
+class KtorUserRemoteDataSource @Inject constructor(
+    @AuthorizedClient private val client: HttpClient
+) : UserRemoteDataSource {
+
+    override suspend fun getUserData(): UserData =
+        client.get(resource = UserResource()).body<ApiResponse<UserDataResponse>>()
+            .result.toModel()
+}

--- a/core/network/src/main/kotlin/com/hyunjung/aiku/core/network/datasource/UserRemoteDataSource.kt
+++ b/core/network/src/main/kotlin/com/hyunjung/aiku/core/network/datasource/UserRemoteDataSource.kt
@@ -1,0 +1,8 @@
+package com.hyunjung.aiku.core.network.datasource
+
+import com.hyunjung.aiku.core.model.UserData
+
+interface UserRemoteDataSource {
+
+    suspend fun getUserData(): UserData
+}

--- a/core/network/src/main/kotlin/com/hyunjung/aiku/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/kotlin/com/hyunjung/aiku/core/network/di/NetworkModule.kt
@@ -1,11 +1,13 @@
 package com.hyunjung.aiku.core.network.di
 
 import com.hyunjung.aiku.core.network.datasource.AuthRemoteDataSource
-import com.hyunjung.aiku.core.network.datasource.KtorAuthRemoteDataSource
 import com.hyunjung.aiku.core.network.datasource.GroupRemoteDataSource
+import com.hyunjung.aiku.core.network.datasource.KtorAuthRemoteDataSource
 import com.hyunjung.aiku.core.network.datasource.KtorGroupRemoteDataSource
 import com.hyunjung.aiku.core.network.datasource.KtorScheduleRemoteDataSource
+import com.hyunjung.aiku.core.network.datasource.KtorUserRemoteDataSource
 import com.hyunjung.aiku.core.network.datasource.ScheduleRemoteDataSource
+import com.hyunjung.aiku.core.network.datasource.UserRemoteDataSource
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -29,4 +31,9 @@ internal abstract class NetworkModule {
     abstract fun bindScheduleRemoteDataSource(
         scheduleRemoteDataSource: KtorScheduleRemoteDataSource
     ): ScheduleRemoteDataSource
+
+    @Binds
+    abstract fun bindUserRemoteDataSource(
+        userRemoteDataSource: KtorUserRemoteDataSource
+    ): UserRemoteDataSource
 }

--- a/core/network/src/main/kotlin/com/hyunjung/aiku/core/network/model/UserDataResponse.kt
+++ b/core/network/src/main/kotlin/com/hyunjung/aiku/core/network/model/UserDataResponse.kt
@@ -1,0 +1,23 @@
+package com.hyunjung.aiku.core.network.model
+
+import com.hyunjung.aiku.core.model.UserData
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UserDataResponse(
+    val memberId: Long,
+    val nickname: String,
+    val kakaoId: String?,
+    val memberProfile: MemberProfileResponse,
+    val point: Int,
+)
+
+fun UserDataResponse.toModel(): UserData =
+    UserData(
+        id = memberId,
+        point = point,
+        email = kakaoId ?: "",
+        kakaoId = kakaoId ?: "",
+        nickname = nickname,
+        profileImage = memberProfile.toModel(),
+    )

--- a/core/network/src/test/kotlin/com/hyunjung/aiku/core/network/datasource/KtorUserRemoteDataSource.kt
+++ b/core/network/src/test/kotlin/com/hyunjung/aiku/core/network/datasource/KtorUserRemoteDataSource.kt
@@ -1,0 +1,39 @@
+package com.hyunjung.aiku.core.network.datasource
+
+import com.hyunjung.aiku.core.model.UserData
+import com.hyunjung.aiku.core.network.datasource.mock.userMockEngine
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.resources.Resources
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class KtorUserRemoteDataSourceTest {
+    private lateinit var subject: UserRemoteDataSource
+
+    @BeforeTest
+    fun setup() {
+        subject = KtorUserRemoteDataSource(
+            HttpClient(userMockEngine) {
+                install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+                install(Resources)
+            }
+        )
+    }
+
+    @Test
+    fun `getUserData returns expected user`() = runTest {
+        val user: UserData = subject.getUserData()
+
+        assertEquals(1L, user.id)
+        assertEquals("지정희", user.nickname)
+        assertEquals("012341234", user.kakaoId)
+        assertEquals(0, user.point)
+        assertNotNull(user.profileImage)
+    }
+}

--- a/core/network/src/test/kotlin/com/hyunjung/aiku/core/network/datasource/mock/userMockEngine.kt
+++ b/core/network/src/test/kotlin/com/hyunjung/aiku/core/network/datasource/mock/userMockEngine.kt
@@ -1,0 +1,65 @@
+package com.hyunjung.aiku.core.network.datasource.mock
+
+import com.hyunjung.aiku.core.network.resource.UserResource
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.respondError
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.fullPath
+import io.ktor.http.headersOf
+import io.ktor.resources.href
+import io.ktor.resources.serialization.ResourcesFormat
+
+/**
+ * UserResource 전용 MockEngine
+ *
+ * - GET /user (예: UserResource()) → 사용자 단건 조회 응답
+ * - 그 외 → 404
+ */
+val userMockEngine = MockEngine { request ->
+    val userPath = href(ResourcesFormat(), UserResource())
+
+    when {
+        request.method == HttpMethod.Get && request.url.fullPath == userPath -> respond(
+            content = userJson, // 아래 상수의 JSON 반환
+            status = HttpStatusCode.OK,
+            headers = headersOf(HttpHeaders.ContentType, "application/json")
+        )
+
+        else -> respondError(HttpStatusCode.NotFound)
+    }
+}
+
+/**
+ * 서버 응답 예시
+ *
+ * 주의:
+ * - 현재 샘플은 email 필드가 없고, id 대신 memberId를 내려요.
+ * - DTO(UserDataResponse)와 mapper에서 필드명을 맞춰 매핑하도록 해 주세요.
+ * - profile 관련 키는 서버 스키마에 맞춰 유지했습니다.
+ */
+private const val userJson = """
+{
+  "requestId": "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d",
+  "result": {
+    "memberId": 1,
+    "nickname": "지정희",
+    "kakaoId": "012341234",
+    "memberProfile": {
+      "profileType": "IMG",
+      "profileImg": "http://amazon.s3.image.jpg",
+      "profileCharacter": null,
+      "profileBackground": null
+    },
+    "title": {
+      "titleMemberId": 3,
+      "titleName": "전장의 지배자",
+      "titleDescription": "전장의 지배자",
+      "titleImg": "http://www.image.com"
+    },
+    "point": 0
+  }
+}
+"""


### PR DESCRIPTION
# PULL REQUEST
- 원격 사용자 정보 조회 기능 구현, 의존성 주입 설정 및 단위 테스트 추가

## Description
### 데이터 전송 객체(DTO) 및 매핑 함수 추가
- 네트워크 계층에서 사용자 정보를 수신하기 위한 `UserDataResponse` DTO 정의
  - 서버 응답 스키마에 맞춰 `memberId`, `email`, `kakaoId`, `nickname`, `memberProfile`, `title`, `point` 등의 필드를 포함
- `UserDataResponse` → `UserData` 변환을 위한 `toModel()` 확장 함수 추가
  - 프로필 이미지, 타이틀 등의 하위 객체를 도메인 모델에 맞춰 변환

### 원격 데이터 소스 인터페이스 정의
- `UserRemoteDataSource` 인터페이스 추가
  - 원격 사용자 정보 조회 기능을 추상화
  - `getUserData()` 메서드를 선언

### Ktor 기반 구현체 추가
- `KtorUserRemoteDataSource` 클래스 구현
  - `UserRemoteDataSource` 인터페이스 구현
  - `@AuthorizedClient`로 주입받은 `HttpClient`를 사용
  - `UserResource`를 통해 서버에 GET 요청을 보내고, 응답(`ApiResponse<UserDataResponse>`)을 받아 `UserData`로 매핑 후 반환

### 의존성 주입 설정
- `NetworkModule`에 `UserRemoteDataSource`와 `KtorUserRemoteDataSource`를 바인딩
  - Hilt를 통해 구현체를 의존성으로 주입할 수 있도록 설정

### 단위 테스트 추가
- `KtorUserRemoteDataSourceTest` 작성
  - `MockEngine`을 사용하여 `UserResource` API 응답을 시뮬레이션
  - 정상 응답 시 `getUserData()`가 예상된 `UserData`를 반환하는지 검증
